### PR TITLE
Improved docs

### DIFF
--- a/lib/src/assert/macros.rs
+++ b/lib/src/assert/macros.rs
@@ -79,9 +79,8 @@ macro_rules! assert_helper {
     }}
 }
 
-/// Assert that condition is true every time this function is called, AND that it is 
-/// called at least once. This test property will be viewable in the "Antithesis SDK: Always" 
-/// group of your triage report.
+/// Assert that condition is true every time this function is called, **and** that it is 
+/// called at least once. The corresponding test property will be viewable in the Antithesis SDK: Always group of your triage report.
 #[macro_export]
 macro_rules! assert_always {
     ($condition:expr, $message:literal, $details:expr) => {
@@ -89,10 +88,8 @@ macro_rules! assert_always {
     }
 }
 
-/// Assert that condition is true every time this function is called. Unlike the Always 
-/// function, the test property spawned by AlwaysOrUnreachable will not be marked as 
-/// failing if the function is never invoked. This test property will be viewable in 
-/// the "Antithesis SDK: Always" group of your triage report.
+/// Assert that condition is true every time this function is called. The corresponding test property will pass if the assertion is never encountered (unlike Always assertion types). 
+/// This test property will be viewable in the “Antithesis SDK: Always” group of your triage report.
 #[macro_export]
 macro_rules! assert_always_or_unreachable {
     ($condition:expr, $message:literal, $details:expr) => {
@@ -101,9 +98,8 @@ macro_rules! assert_always_or_unreachable {
 }
 
 /// Assert that condition is true at least one time that this function was called. 
-/// The test property spawned by Sometimes will be marked as failing if this function 
-/// is never called, or if condition is false every time that it is called. This 
-/// test property will be viewable in the "Antithesis SDK: Sometimes" group.
+/// (If the assertion is never encountered, the test property will therefore fail.) 
+/// This test property will be viewable in the “Antithesis SDK: Sometimes” group.
 #[macro_export]
 macro_rules! assert_sometimes {
     ($condition:expr, $message:literal, $details:expr) => {
@@ -111,9 +107,9 @@ macro_rules! assert_sometimes {
     }
 }
 
-/// Assert that a line of code is reached at least once. The test property spawned by 
-/// Reachable will be marked as failing if this function is never called. This test 
-/// property will be viewable in the "Antithesis SDK: Reachablity assertions" group.
+/// Assert that a line of code is reached at least once. 
+/// The corresponding test property will pass if this macro is ever called. (If it is never called the test property will therefore fail.) 
+/// This test property will be viewable in the “Antithesis SDK: Reachablity assertions” group.
 #[macro_export]
 macro_rules! assert_reachable {
     ($message:literal, $details:expr) => {
@@ -121,9 +117,10 @@ macro_rules! assert_reachable {
     }
 }
 
-/// Assert that a line of code is never reached. The test property spawned by Unreachable 
-/// will be marked as failing if this function is ever called. This test property will 
-/// be viewable in the "Antithesis SDK: Reachablity assertions" group.
+/// Assert that a line of code is never reached. 
+/// The corresponding test property will fail if this macro is ever called. 
+/// (If it is never called the test property will therefore pass.) 
+/// This test property will be viewable in the “Antithesis SDK: Reachablity assertions” group.
 #[macro_export]
 macro_rules! assert_unreachable {
     ($message:literal, $details:expr) => {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,7 +1,7 @@
 /// The assert module allows you to define new test properties 
 /// for your program or workload.
 ///
-/// If the environment variable ANTITHESIS_SDK_LOCAL_OUTPUT is 
+/// Whenever the environment variable ANTITHESIS_SDK_LOCAL_OUTPUT is 
 /// set, these macros and functions will log to the file pointed 
 /// to by that variable using a structured JSON format defined in 
 /// the Antithesis SDK docs.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,5 @@
-/// The assert module allows you to define new test properties 
-/// for your program or workload.
+/// The assert module enables defining [test properties](https://antithesis.com/docs/using_antithesis/properties.html) 
+/// about your program or [workload](https://antithesis.com/docs/getting_started/workload.html).
 ///
 /// Whenever the environment variable ANTITHESIS_SDK_LOCAL_OUTPUT is 
 /// set, these macros and functions will log to the file pointed 
@@ -8,22 +8,14 @@
 /// This allows you to make use of the Antithesis assertions module 
 /// in your regular testing, or even in production. In particular, 
 /// very few assertions frameworks offer a convenient way to define 
-/// [Sometimes assertions], but they can be quite useful even outside 
+/// [Sometimes assertions](https://antithesis.com/docs/best_practices/sometimes_assertions.html), but they can be quite useful even outside 
 /// Antithesis.
 ///
-/// Each macro/function in this module takes a parameter called message. 
-/// This value of this parameter will become part of the name of 
-/// the test property defined by the function, and will be viewable 
-/// in your [triage report], so it should be human interpretable. 
-/// Assertions in different parts of your code with the same message 
-/// value will be grouped into the same test property, but if one of 
-/// them fails you will be able to see which file and line number are 
-/// associated with each failure.
+/// Each macro/function in this module takes a parameter called message, which is 
+/// a human readable identifier used to aggregate assertions. 
+/// Antithesis generates one test property per unique message and this test property will be named "<message>" in the [triage report](https://antithesis.com/docs/reports/triage.html).
 ///
-/// Each macro/function also takes a parameter called details. 
-/// This parameter allows you to optionally provide a JSON representation
-/// of context information that will be viewable in the 'details' 
-/// tab for any example or counterexample of the associated property.
+/// Each macro/function also takes a parameter called details, which is a key-value map of optional additional information provided by the user to add context for assertion failures. The information that is logged will appear in the logs section of a [triage report](https://antithesis.com/docs/reports/triage.html). Normally the values passed to details are evaluated at runtime.
 pub mod assert;
 
 // External crates used in assertion macros
@@ -37,20 +29,15 @@ pub use linkme;
 pub mod lifecycle;
 
 
-/// The random module provides an interface that allows your program 
-/// to ask the Antithesis platform for random entropy. These functions 
-/// are also safe to call outside the Antithesis environment, where 
-/// they will fall back on values from the rust std library
+/// The random module provides functions that request both structured and unstructured randomness from the Antithesis environment.
+/// 
+/// These functions should not be used to seed a conventional PRNG, and should not have their return values stored and used to make a decision at a later time. 
+/// Doing either of these things makes it much harder for the Antithesis platform to control the history of your program's execution, and also makes it harder for Antithesis to learn which inputs provided at which times are most fruitful. 
+/// Instead, you should call a function from the random package every time your program or [workload](https://antithesis.com/docs/getting_started/workload.html) needs to make a decision, at the moment that you need to make the decision.
+/// 
+/// These functions are also safe to call outside the Antithesis environment, where 
+/// they will fall back on values from the rust std library.
 ///
-/// These functions should not be used to seed a conventional PRNG, 
-/// and should not have their return values stored and used to make a 
-/// decision at a later time. Doing either of these things makes it 
-/// much harder for the Antithesis platform to control the history of 
-/// your program's execution, and also makes it harder for Antithesis 
-/// to learn which inputs provided at which times are most fruitful. 
-/// Instead, you should call a function from the random package every 
-/// time your program or workload needs to make a decision, at the 
-/// moment that you need to make the decision.
 pub mod random;
 
 mod internal;

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -16,13 +16,11 @@ struct SetupCompleteData<'a> {
     antithesis_setup: AntithesisSetupData<'a, 'a>,
 }
 
-/// Call this function when your system and workload are fully initialized. 
-/// After this function is called, the Antithesis environment will take a 
-/// snapshot of your system and begin [injecting faults].
+/// Indicates to Antithesis that setup has completed. Call this function when your system and workload are fully initialized. 
+/// After this function is called, Antithesis will take a snapshot of your system and begin [injecting faults]( https://antithesis.com/docs/applications/reliability/fault_injection.html).
 ///
-/// Calling this function multiple times, or from multiple processes, will 
-/// have no effect. Antithesis will treat the first time any process called 
-/// this function as the moment that the setup was completed.
+/// Calling this function multiple times or from multiple processes will have no effect. 
+/// Antithesis will treat the first time any process called this function as the moment that the setup was completed.
 pub fn setup_complete(details: &Value) {
     let status = "complete";
     let antithesis_setup = AntithesisSetupData::<'_, '_>{
@@ -37,8 +35,9 @@ pub fn setup_complete(details: &Value) {
     internal::dispatch_output(&setup_complete_data)
 }
 
-/// Causes an event with the name and details provided,
-/// to be sent to the Fuzzer and Notebook
+/// Indicates to Antithesis that a certain event has been reached. It provides greater information about the ordering of events during the course of testing in Antithesis.
+/// 
+/// In addition to details, you also provide an eventName, which is the name of the event that you are logging. This name will appear in the logs section of a [triage report](https://antithesis.com/docs/reports/triage.html).
 pub fn send_event(name: &str, details: &Value) {
     let trimmed_name = name.trim();
     let owned_name: String = if trimmed_name.is_empty() {

--- a/lib/src/random.rs
+++ b/lib/src/random.rs
@@ -51,7 +51,7 @@ mod tests {
     fn random_choice_few_choices() {
         
         // For each map key, the value is the count of the number of
-        // randiom_choice responses received matching that key
+        // random_choice responses received matching that key
         let mut counted_items: HashMap<&str, i64> = HashMap::new();
         counted_items.insert("a", 0);
         counted_items.insert("b", 0);


### PR DESCRIPTION
[x] assert - the links to [Sometimes assertions] and [triage report] don't show up as a links.
[x] send_event - I see we've got the same docs in the go one. But is Notebook a customer-visible concept?
[x] setup_complete - broken link