### PR TITLE
Updated crate name to antithesis_sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 3
 
 [[package]]
-name = "antithesis_sdk_rust"
+name = "antithesis_sdk"
 version = "0.1.0"
 dependencies = [
  "libc",
@@ -201,7 +201,7 @@ dependencies = [
 name = "simple"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk_rust",
+ "antithesis_sdk",
  "serde_json",
 ]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "antithesis_sdk_rust"
+name = "antithesis_sdk"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.62.1"

--- a/lib/src/assert/macros.rs
+++ b/lib/src/assert/macros.rs
@@ -79,8 +79,22 @@ macro_rules! assert_helper {
     }};
 }
 
-/// Assert that condition is true every time this function is called, **and** that it is 
+/// Assert that condition is true every time this function is called, **and** that it is
 /// called at least once. The corresponding test property will be viewable in the Antithesis SDK: Always group of your triage report.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json};
+/// use antithesis_sdk::{assert_always, random};
+///
+/// const MAX_ALLOWED: u64 = 100;
+/// let actual = random::get_random() % 100u64;
+/// let details = json!({"max_allowed": MAX_ALLOWED, "actual": actual});
+/// antithesis_sdk::assert_always!(actual < MAX_ALLOWED, "Value in range", &details);
+///
+/// assert!(actual < MAX_ALLOWED)
+/// ```
 #[macro_export]
 macro_rules! assert_always {
     ($condition:expr, $message:literal, $details:expr) => {
@@ -88,15 +102,29 @@ macro_rules! assert_always {
             condition = $condition,
             $message,
             $details,
-            AssertType::Always,
+            $crate::assert::AssertType::Always,
             "Always",
             must_hit = true
         )
     };
 }
 
-/// Assert that condition is true every time this function is called. The corresponding test property will pass if the assertion is never encountered (unlike Always assertion types). 
+/// Assert that condition is true every time this function is called. The corresponding test property will pass if the assertion is never encountered (unlike Always assertion types).
 /// This test property will be viewable in the “Antithesis SDK: Always” group of your triage report.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json};
+/// use antithesis_sdk::{assert_always_or_unreachable, random};
+///
+/// const MAX_ALLOWED: u64 = 100;
+/// let actual = random::get_random() % 100u64;
+/// let details = json!({"max_allowed": MAX_ALLOWED, "actual": actual});
+/// antithesis_sdk::assert_always_or_unreachable!(actual < MAX_ALLOWED, "Value in range", &details);
+///
+/// assert!(actual < MAX_ALLOWED)
+/// ```
 #[macro_export]
 macro_rules! assert_always_or_unreachable {
     ($condition:expr, $message:literal, $details:expr) => {
@@ -104,16 +132,30 @@ macro_rules! assert_always_or_unreachable {
             condition = $condition,
             $message,
             $details,
-            AssertType::Always,
+            $crate::assert::AssertType::Always,
             "AlwaysOrUnreachable",
             must_hit = false
         )
     };
 }
 
-/// Assert that condition is true at least one time that this function was called. 
-/// (If the assertion is never encountered, the test property will therefore fail.) 
+/// Assert that condition is true at least one time that this function was called.
+/// (If the assertion is never encountered, the test property will therefore fail.)
 /// This test property will be viewable in the “Antithesis SDK: Sometimes” group.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json};
+/// use antithesis_sdk::{assert_sometimes, random};
+///
+/// const MAX_ALLOWED: u64 = 100;
+/// let actual = random::get_random() % 120u64;
+/// let details = json!({"max_allowed": MAX_ALLOWED, "actual": actual});
+/// antithesis_sdk::assert_sometimes!(actual > MAX_ALLOWED, "Value in range", &details);
+///
+/// assert!(actual < 120u64)
+/// ```
 #[macro_export]
 macro_rules! assert_sometimes {
     ($condition:expr, $message:literal, $details:expr) => {
@@ -121,16 +163,32 @@ macro_rules! assert_sometimes {
             condition = $condition,
             $message,
             $details,
-            AssertType::Sometimes,
+            $crate::assert::AssertType::Sometimes,
             "Sometimes",
             must_hit = true
         )
     };
 }
 
-/// Assert that a line of code is reached at least once. 
-/// The corresponding test property will pass if this macro is ever called. (If it is never called the test property will therefore fail.) 
+/// Assert that a line of code is reached at least once.
+/// The corresponding test property will pass if this macro is ever called. (If it is never called the test property will therefore fail.)
 /// This test property will be viewable in the “Antithesis SDK: Reachablity assertions” group.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json};
+/// use antithesis_sdk::{assert_reachable, random};
+///
+/// const MAX_ALLOWED: u64 = 100;
+/// let actual = random::get_random() % 120u64;
+/// let details = json!({"max_allowed": MAX_ALLOWED, "actual": actual});
+/// if (actual > MAX_ALLOWED) {
+///     antithesis_sdk::assert_reachable!("Value in range", &details);
+/// }
+///
+/// assert!(actual < 120u64)
+/// ```
 #[macro_export]
 macro_rules! assert_reachable {
     ($message:literal, $details:expr) => {
@@ -138,17 +196,33 @@ macro_rules! assert_reachable {
             condition = true,
             $message,
             $details,
-            AssertType::Reachability,
+            $crate::assert::AssertType::Reachability,
             "Reachable",
             must_hit = true
         )
     };
 }
 
-/// Assert that a line of code is never reached. 
-/// The corresponding test property will fail if this macro is ever called. 
-/// (If it is never called the test property will therefore pass.) 
+/// Assert that a line of code is never reached.
+/// The corresponding test property will fail if this macro is ever called.
+/// (If it is never called the test property will therefore pass.)
 /// This test property will be viewable in the “Antithesis SDK: Reachablity assertions” group.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json};
+/// use antithesis_sdk::{assert_unreachable, random};
+///
+/// const MAX_ALLOWED: u64 = 100;
+/// let actual = random::get_random() % 120u64;
+/// let details = json!({"max_allowed": MAX_ALLOWED, "actual": actual});
+/// if (actual > 120u64) {
+///     antithesis_sdk::assert_unreachable!("Value is above range", &details);
+/// }
+///
+/// assert!(actual < 120u64)
+/// ```
 #[macro_export]
 macro_rules! assert_unreachable {
     ($message:literal, $details:expr) => {
@@ -156,7 +230,7 @@ macro_rules! assert_unreachable {
             condition = false,
             $message,
             $details,
-            AssertType::Reachability,
+            $crate::assert::AssertType::Reachability,
             "Unreachable",
             must_hit = false
         )

--- a/lib/src/internal/mod.rs
+++ b/lib/src/internal/mod.rs
@@ -52,7 +52,7 @@ pub(crate) trait LibHandler {
     fn random(&self) -> u64;
 }
 
-// Made public so it can be invoked from the antithesis_sdk_rust::random module
+// Made public so it can be invoked from the antithesis_sdk::random module
 pub(crate) fn dispatch_random() -> u64 {
     LIB_HANDLER.random()
 }
@@ -71,8 +71,8 @@ pub(crate) fn dispatch_random() -> u64 {
 // and report detected io:Error's but there is no requirement
 // to implement this.
 //
-// Made public so it can be invoked from the antithesis_sdk_rust::lifecycle
-// and antithesis_sdk_rust::assert module
+// Made public so it can be invoked from the antithesis_sdk::lifecycle
+// and antithesis_sdk::assert module
 pub fn dispatch_output<T: Serialize + ?Sized>(json_data: &T) {
     let s = serde_json::to_string(json_data).unwrap_or("{}".to_owned());
     let _ = LIB_HANDLER.output(s.as_str());

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,22 +1,22 @@
-/// The assert module enables defining [test properties](https://antithesis.com/docs/using_antithesis/properties.html) 
+/// The assert module enables defining [test properties](https://antithesis.com/docs/using_antithesis/properties.html)
 /// about your program or [workload](https://antithesis.com/docs/getting_started/workload.html).
 ///
-/// Whenever the environment variable ANTITHESIS_SDK_LOCAL_OUTPUT is 
-/// set, these macros and functions will log to the file pointed 
-/// to by that variable using a structured JSON format defined in 
+/// Whenever the environment variable ANTITHESIS_SDK_LOCAL_OUTPUT is
+/// set, these macros and functions will log to the file pointed
+/// to by that variable using a structured JSON format defined in
 /// the Antithesis SDK docs.
-/// This allows you to make use of the Antithesis assertions module 
-/// in your regular testing, or even in production. In particular, 
-/// very few assertions frameworks offer a convenient way to define 
-/// [Sometimes assertions](https://antithesis.com/docs/best_practices/sometimes_assertions.html), but they can be quite useful even outside 
+/// This allows you to make use of the Antithesis assertions module
+/// in your regular testing, or even in production. In particular,
+/// very few assertions frameworks offer a convenient way to define
+/// [Sometimes assertions](https://antithesis.com/docs/best_practices/sometimes_assertions.html), but they can be quite useful even outside
 /// Antithesis.
 ///
-/// Each macro/function in this module takes a parameter called message, which is 
-/// a human readable identifier used to aggregate assertions. 
+/// Each macro/function in this module takes a parameter called message, which is
+/// a human readable identifier used to aggregate assertions.
 /// Antithesis generates one test property per unique message and this test property will be named "message" in the [triage report](https://antithesis.com/docs/reports/triage.html).
 ///
-/// Each macro/function also takes a parameter called details, which is a key-value map of optional additional information provided by the user to add context for assertion failures. 
-/// The information that is logged will appear in the logs section of a [triage report](https://antithesis.com/docs/reports/triage.html). 
+/// Each macro/function also takes a parameter called details, which is a key-value map of optional additional information provided by the user to add context for assertion failures.
+/// The information that is logged will appear in the logs section of a [triage report](https://antithesis.com/docs/reports/triage.html).
 /// Normally the values passed to details are evaluated at runtime.
 pub mod assert;
 
@@ -31,12 +31,12 @@ pub use once_cell;
 pub mod lifecycle;
 
 /// The random module provides functions that request both structured and unstructured randomness from the Antithesis environment.
-/// 
-/// These functions should not be used to seed a conventional PRNG, and should not have their return values stored and used to make a decision at a later time. 
-/// Doing either of these things makes it much harder for the Antithesis platform to control the history of your program's execution, and also makes it harder for Antithesis to learn which inputs provided at which times are most fruitful. 
+///
+/// These functions should not be used to seed a conventional PRNG, and should not have their return values stored and used to make a decision at a later time.
+/// Doing either of these things makes it much harder for the Antithesis platform to control the history of your program's execution, and also makes it harder for Antithesis to learn which inputs provided at which times are most fruitful.
 /// Instead, you should call a function from the random package every time your program or [workload](https://antithesis.com/docs/getting_started/workload.html) needs to make a decision, at the moment that you need to make the decision.
-/// 
-/// These functions are also safe to call outside the Antithesis environment, where 
+///
+/// These functions are also safe to call outside the Antithesis environment, where
 /// they will fall back on values from the rust std library.
 ///
 pub mod random;
@@ -46,7 +46,37 @@ mod internal;
 /// Convenience to import all macros and functions
 pub mod prelude;
 
-/// Global initialization logic
+/// Global initialization logic.  Performs registration of the
+/// Antithesis assertion catalog.  This should be invoked as early as
+/// possible during program execution (invoke first thing in main).
+///
+/// If invoked more than once, only the first call will result
+/// in the assertion catalog being registered.  If not invoked at all,
+/// the assertion catalog will be registered upon the first
+/// assertion that is encountered at runtime.
+///
+/// Warning - if assertions are included in a program, and not
+/// encountered at runtime, and antithesis_init() has not been
+/// called, then the assertions will not be reported.
+///
+/// Example:
+///
+/// ```
+/// use std::env;
+/// use serde_json::{json};
+/// use antithesis_sdk::antithesis_init;
+/// use antithesis_sdk::{assert_unreachable};
+///
+/// fn main() {
+///     if (env::args_os().len() == 1888999778899) {
+///         assert_unreachable!("Unable to provide trillions of arguments", &json!({}));
+///     }
+///     
+///     // if antithesis_init() is omitted, the above unreachable will
+///     // not be reported
+///     antithesis_init();
+/// }
+/// ```
 pub fn antithesis_init() {
     Lazy::force(&internal::LIB_HANDLER);
     Lazy::force(&assert::INIT_CATALOG);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -64,10 +64,8 @@ pub mod prelude;
 /// ```
 /// use std::env;
 /// use serde_json::{json};
-/// use antithesis_sdk::antithesis_init;
-/// use antithesis_sdk::{assert_unreachable};
+/// use antithesis_sdk::{antithesis_init, assert_unreachable};
 ///
-/// #[allow(clippy::needless_doctest_main)]
 /// fn main() {
 ///     if (env::args_os().len() == 1888999778899) {
 ///         assert_unreachable!("Unable to provide trillions of arguments", &json!({}));
@@ -78,6 +76,7 @@ pub mod prelude;
 ///     antithesis_init();
 /// }
 /// ```
+#[allow(clippy::needless_doctest_main)]
 pub fn antithesis_init() {
     Lazy::force(&internal::LIB_HANDLER);
     Lazy::force(&assert::INIT_CATALOG);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -67,6 +67,7 @@ pub mod prelude;
 /// use antithesis_sdk::antithesis_init;
 /// use antithesis_sdk::{assert_unreachable};
 ///
+/// #[allow(clippy::needless_doctestt_main)]
 /// fn main() {
 ///     if (env::args_os().len() == 1888999778899) {
 ///         assert_unreachable!("Unable to provide trillions of arguments", &json!({}));

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -67,7 +67,7 @@ pub mod prelude;
 /// use antithesis_sdk::antithesis_init;
 /// use antithesis_sdk::{assert_unreachable};
 ///
-/// #[allow(clippy::needless_doctestt_main)]
+/// #[allow(clippy::needless_doctest_main)]
 /// fn main() {
 ///     if (env::args_os().len() == 1888999778899) {
 ///         assert_unreachable!("Unable to provide trillions of arguments", &json!({}));

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -16,11 +16,27 @@ struct SetupCompleteData<'a> {
     antithesis_setup: AntithesisSetupData<'a, 'a>,
 }
 
-/// Indicates to Antithesis that setup has completed. Call this function when your system and workload are fully initialized. 
+/// Indicates to Antithesis that setup has completed. Call this function when your system and workload are fully initialized.
 /// After this function is called, Antithesis will take a snapshot of your system and begin [injecting faults]( https://antithesis.com/docs/applications/reliability/fault_injection.html).
 ///
-/// Calling this function multiple times or from multiple processes will have no effect. 
+/// Calling this function multiple times or from multiple processes will have no effect.
 /// Antithesis will treat the first time any process called this function as the moment that the setup was completed.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json, Value};
+/// use antithesis_sdk::lifecycle;
+///
+/// let (num_nodes, main_id) = (10, "n-001");
+///
+/// let startup_data: Value = json!({
+///     "num_nodes": num_nodes,
+///     "main_node_id": main_id,
+/// });
+///
+/// lifecycle::setup_complete(&startup_data);
+/// ```
 pub fn setup_complete(details: &Value) {
     let status = "complete";
     let antithesis_setup = AntithesisSetupData::<'_, '_> { status, details };
@@ -31,8 +47,22 @@ pub fn setup_complete(details: &Value) {
 }
 
 /// Indicates to Antithesis that a certain event has been reached. It provides greater information about the ordering of events during the course of testing in Antithesis.
-/// 
+///
 /// In addition to details, you also provide an eventName, which is the name of the event that you are logging. This name will appear in the logs section of a [triage report](https://antithesis.com/docs/reports/triage.html).
+///
+/// # Example
+///
+/// ```
+/// use serde_json::{json, Value};
+/// use antithesis_sdk::lifecycle;
+///
+/// let info_value: Value = json!({
+///     "month": "July",
+///     "day": 17
+/// });
+///
+/// lifecycle::send_event("start_day", &info_value);
+/// ```
 pub fn send_event(name: &str, details: &Value) {
     let trimmed_name = name.trim();
     let owned_name: String = if trimmed_name.is_empty() {
@@ -40,9 +70,7 @@ pub fn send_event(name: &str, details: &Value) {
     } else {
         trimmed_name.to_owned()
     };
-    let json_event = json!({
-        owned_name: details
-    });
+    let json_event = json!({ owned_name: details });
     internal::dispatch_output(&json_event)
 }
 

--- a/lib/src/random.rs
+++ b/lib/src/random.rs
@@ -3,6 +3,15 @@ use crate::internal;
 /// Returns a uint64 value chosen by Antithesis. You should not
 /// store this value or use it to seed a PRNG, but should use it
 /// immediately.
+///
+/// # Example
+///
+/// ```
+/// use antithesis_sdk::random;
+///
+/// let value = random::get_random();
+/// println!("Random value(u64): {value}");
+/// ```
 pub fn get_random() -> u64 {
     internal::dispatch_random()
 }
@@ -14,6 +23,17 @@ pub fn get_random() -> u64 {
 /// the Antithesis platform that you intend to use a random value
 /// in a structured way enables it to provide more interesting
 /// choices over time.
+///
+/// # Example
+///
+/// ```
+/// use antithesis_sdk::random;
+///
+/// let choices: Vec<&str> = vec!["abc", "def", "xyz", "qrs"];
+/// if let Some(s) = random::random_choice(choices.as_slice()) {
+///     println!("Choice: '{s}'");
+/// };
+/// ```
 pub fn random_choice<T>(slice: &[T]) -> Option<&T> {
     match slice {
         [] => None,

--- a/lib/tests/sdk_info.rs
+++ b/lib/tests/sdk_info.rs
@@ -1,4 +1,4 @@
-use antithesis_sdk_rust::lifecycle;
+use antithesis_sdk::lifecycle;
 use serde_json::json;
 
 mod common;

--- a/lib/tests/send_event.rs
+++ b/lib/tests/send_event.rs
@@ -1,4 +1,4 @@
-use antithesis_sdk_rust::lifecycle;
+use antithesis_sdk::lifecycle;
 use serde_json::json;
 
 mod common;

--- a/lib/tests/setup_complete_with_details.rs
+++ b/lib/tests/setup_complete_with_details.rs
@@ -1,4 +1,4 @@
-use antithesis_sdk_rust::lifecycle;
+use antithesis_sdk::lifecycle;
 use serde_json::{json, Value};
 
 mod common;

--- a/lib/tests/setup_complete_without_details.rs
+++ b/lib/tests/setup_complete_without_details.rs
@@ -1,4 +1,4 @@
-use antithesis_sdk_rust::lifecycle;
+use antithesis_sdk::lifecycle;
 use serde_json::json;
 
 mod common;

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-antithesis_sdk_rust = { path = "../lib" }
+antithesis_sdk = { path = "../lib" }
 serde_json = "1.0.25"

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -1,6 +1,6 @@
 use serde_json::{json, Value};
 
-use antithesis_sdk_rust::prelude::*;
+use antithesis_sdk::prelude::*;
 
 #[allow(dead_code)]
 fn random_demo() {


### PR DESCRIPTION
Changed the crate name to `antithesis-sdk`
Ensure that a full `$crate` anchored reference to `AssertType` is used by related assertion macros
Documented examples and functions as indicated below:

[X] (Not a docs issue per-se): it says we re-export assert_impl, assert_raw, and CatalogInfo. Do we need to export all of those, or should some of those be pub(crate) or something like that?
(a) assert_impl() - Macro calls like `assert_sometimes!()` expand to `assert_impl()`.
(b) CatalogInfo - Macro calls  `assert_sometimes!()` expand to `static CAT_ITEM: CatalogInfo`
(c) assert_raw() - Is intended to be public (and documented)

[X] Top-level doc (crate antithesis_sdk_rust/index.html) should have a brief textual description and link to our docs. Possibly this could just be lifted from the README. Actually, it probably also needs an example that shows that you call the init function in main and with an assertion or two.

[X] assert - the links to [Sometimes assertions] and [triage report] don't show up as a links.

[X] assert - it feels like we shouldn't be exporting/documenting anything we don't intend for a customer to use directly. So CatalogInfo, ANTITHESIS_CATALOG, and assert_raw seem suspect.
-- see above --

[X] assert_raw seems like we ought to document it. If we intend for third-party frameworks to use it, we ought to spell out things like what the parameters mean. Actually, I'm looking at other crates, and it seems that they don't spell out param-by-param what things are; they just have an example in their docs. Example

[X] send_event - I see we've got the same docs in the go one.

[X] setup_complete - broken link

[X] All the macros - would benefit from an example of using each one.
 [X] lifecycle: setup_complete()
 [X] lifecycle: send_event()
 [X] random::get_random()
 [X] random::random_choice()
 [X] assert::assert_raw()
 [X] antithesis_init()
 [X] assert_always()
 [X] assert_sometimes()
 [X] assert_always_or_unreachable()
 [X] assert_reachable()
 [X] assert_unreachable()