### PR TITLE
Invert feature flags to allow for optional dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "antithesis_sdk"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "libc",
  "libloading",

--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ For general usage guidance see the [Antithesis Rust SDK Documentation](https://a
 
 ### Notes
 
-To disable assertions use this feature flag for cargo builds:
-
-    -F no-antithesis-sdk
+To disable assertions disable `default-features` for this crate.
 
 When assertions are disabled, the `condition` and `detail` arguments specified
-for assertions will be evaluated, but no assertions will be emitted, or otherwise processed.  
+for assertions will be evaluated, but no assertions will be emitted, or otherwise processed.
 
-In this case (using feature flag `no-antithesis-sdk`), the assert macros will expand to 
-nothing (other than the evaluation of `condition` and `details`)
+In this case, the assert macros will expand to
+nothing (other than the evaluation of `condition` and `details`).

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,12 +17,17 @@ Rust SDK for the Antithesis autonomous software testing platform.
 [dependencies]
 serde = { version = "1.0.113", features = ["derive"] }
 serde_json = "1.0.25"
-libloading = "0.8"
-libc = "0.2.64"
 rand = "0.8"
-rustc_version_runtime = "0.3"
-once_cell = "1"
-linkme = "0.3.17"
+rustc_version_runtime = "0.3" # could maybe remove this since no op handler wont call it
+once_cell = "1" # TODO: could probably remove this with some more feature flagging
+
+# needed 
+libloading = {version = "0.8", optional = true}
+libc = {version = "0.2.64", optional = true}
+linkme = {version = "0.3.17", optional = true}
+
+
 
 [features]
-no-antithesis-sdk = []
+default = ["full"]
+full = ["dep:libloading", "dep:libc", "dep:linkme"] # TODO figure out real name

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,9 +19,9 @@ serde = { version = "1.0.113", features = ["derive"] }
 serde_json = "1.0.25"
 rand = "0.8"
 rustc_version_runtime = "0.3" # could maybe remove this since no op handler wont call it
-once_cell = "1" # TODO: could probably remove this with some more feature flagging
 
-# needed 
+# needed only if full feature is set
+once_cell = {version = "1", optional = true}
 libloading = {version = "0.8", optional = true}
 libc = {version = "0.2.64", optional = true}
 linkme = {version = "0.3.17", optional = true}
@@ -30,4 +30,4 @@ linkme = {version = "0.3.17", optional = true}
 
 [features]
 default = ["full"]
-full = ["dep:libloading", "dep:libc", "dep:linkme"] # TODO figure out real name
+full = ["dep:libloading", "dep:libc", "dep:linkme", "dep:once_cell"] # TODO figure out real name

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "antithesis_sdk"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.62.1"
 license = "MIT"
@@ -25,7 +25,6 @@ once_cell = {version = "1", optional = true}
 libloading = {version = "0.8", optional = true}
 libc = {version = "0.2.64", optional = true}
 linkme = {version = "0.3.17", optional = true}
-
 
 
 [features]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,9 +18,9 @@ Rust SDK for the Antithesis autonomous software testing platform.
 serde = { version = "1.0.113", features = ["derive"] }
 serde_json = "1.0.25"
 rand = "0.8"
-rustc_version_runtime = "0.3" # could maybe remove this since no op handler wont call it
 
 # needed only if full feature is set
+rustc_version_runtime = {version = "0.3", optional = true}
 once_cell = {version = "1", optional = true}
 libloading = {version = "0.8", optional = true}
 libc = {version = "0.2.64", optional = true}
@@ -29,4 +29,4 @@ linkme = {version = "0.3.17", optional = true}
 
 [features]
 default = ["full"]
-full = ["dep:libloading", "dep:libc", "dep:linkme", "dep:once_cell"] # TODO figure out real name
+full = ["dep:libloading", "dep:libc", "dep:linkme", "dep:once_cell", "dep:rustc_version_runtime"]

--- a/lib/src/assert/macros.rs
+++ b/lib/src/assert/macros.rs
@@ -1,5 +1,5 @@
 /// Common handling used by all the assertion-related macros
-#[cfg(not(feature = "no-antithesis-sdk"))]
+#[cfg(feature = "full")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! assert_helper {
@@ -65,7 +65,8 @@ macro_rules! assert_helper {
         )
     }}; // end pattern-arm block
 }
-#[cfg(feature = "no-antithesis-sdk")]
+
+#[cfg(not(feature = "full"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! assert_helper {

--- a/lib/src/assert/mod.rs
+++ b/lib/src/assert/mod.rs
@@ -1,9 +1,17 @@
+#[cfg(feature = "full")]
 use crate::internal;
+#[cfg(feature = "full")]
 use linkme::distributed_slice;
+#[cfg(feature = "full")]
 use once_cell::sync::Lazy;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::Value;
+#[cfg(feature = "full")]
+use serde_json::json;
+
+#[cfg(feature = "full")]
 use std::collections::HashMap;
+#[cfg(feature = "full")]
 use std::sync::Mutex;
 
 mod macros;
@@ -11,6 +19,7 @@ mod macros;
 /// Catalog of all antithesis assertions provided
 #[doc(hidden)]
 #[distributed_slice]
+#[cfg(feature = "full")]
 pub static ANTITHESIS_CATALOG: [CatalogInfo];
 
 // Only need an ASSET_TRACKER if there are actually assertions 'hit'
@@ -19,9 +28,11 @@ pub static ANTITHESIS_CATALOG: [CatalogInfo];
 // Typically runtime assertions use the macros ``always!``, ``sometimes!``, etc.
 // or, a client is using the 'raw' interface ``assert_raw`` at runtime.
 //
+#[cfg(feature = "full")]
 pub(crate) static ASSERT_TRACKER: Lazy<Mutex<HashMap<String, TrackingInfo>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
+#[cfg(feature = "full")]
 pub(crate) static INIT_CATALOG: Lazy<()> = Lazy::new(|| {
     let no_details: Value = json!({});
     for info in ANTITHESIS_CATALOG.iter() {
@@ -44,17 +55,20 @@ pub(crate) static INIT_CATALOG: Lazy<()> = Lazy::new(|| {
     }
 });
 
+#[cfg(feature = "full")]
 pub(crate) struct TrackingInfo {
     pub pass_count: u64,
     pub fail_count: u64,
 }
 
+#[cfg(feature = "full")]
 impl Default for TrackingInfo {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(feature = "full")]
 impl TrackingInfo {
     pub fn new() -> Self {
         TrackingInfo {
@@ -84,6 +98,7 @@ struct AntithesisLocationInfo {
 /// Internal representation for assertion catalog
 #[doc(hidden)]
 #[derive(Debug)]
+#[cfg(feature = "full")]
 pub struct CatalogInfo {
     pub assert_type: AssertType,
     pub display_type: &'static str,
@@ -148,7 +163,10 @@ impl AssertionInfo {
             details: details.clone(),
         }
     }
+} 
 
+#[cfg(feature = "full")]
+impl AssertionInfo {
     // AssertionInfo::track_entry() determines if the assertion should
     // actually be emitted:
     //
@@ -197,6 +215,14 @@ impl AssertionInfo {
         internal::dispatch_output(&json_event)
     }
 }
+
+#[cfg(not(feature = "full"))]
+impl AssertionInfo {
+    fn track_entry(&self) {
+        return
+    }
+}
+
 
 /// This is a low-level method designed to be used by third-party frameworks.
 /// Regular users of the assert package should not call it.
@@ -373,6 +399,7 @@ pub fn assert_impl(
         id,
         details,
     );
+
     let _ = &assertion.track_entry();
 }
 

--- a/lib/src/internal/mod.rs
+++ b/lib/src/internal/mod.rs
@@ -1,16 +1,24 @@
-use local_handler::LocalHandler;
-use noop_handler::NoOpHandler;
-use once_cell::sync::Lazy;
 use rustc_version_runtime::version;
 use serde::Serialize;
 use std::io::Error;
+
+use noop_handler::NoOpHandler;
 #[cfg(feature = "full")]
 use voidstar_handler::VoidstarHandler;
+#[cfg(feature = "full")]
+use local_handler::LocalHandler;
 
-mod local_handler;
+#[cfg(feature = "full")]
+use once_cell::sync::Lazy;
+
+
 mod noop_handler;
 #[cfg(feature = "full")]
 mod voidstar_handler;
+
+#[cfg(feature = "full")]
+mod local_handler;
+
 
 #[derive(Serialize, Debug)]
 struct AntithesisLanguageInfo {
@@ -54,12 +62,17 @@ fn get_handler() -> Box<dyn LibHandler + Sync + Send> {
     Box::new(NoOpHandler::new())
 }
 
+#[cfg(feature = "full")]
 pub(crate) static LIB_HANDLER: Lazy<Box<dyn LibHandler + Sync + Send>> = Lazy::new(|| {
     let handler = get_handler();
     let s = serde_json::to_string(&sdk_info()).unwrap_or("{}".to_owned());
     let _ = handler.output(s.as_str());
     handler
 });
+
+
+#[cfg(not(feature = "full"))]
+pub(crate) static LIB_HANDLER: NoOpHandler = NoOpHandler{};
 
 pub(crate) trait LibHandler {
     fn output(&self, value: &str) -> Result<(), Error>;

--- a/lib/src/internal/mod.rs
+++ b/lib/src/internal/mod.rs
@@ -1,8 +1,11 @@
-use rustc_version_runtime::version;
 use serde::Serialize;
 use std::io::Error;
 
 use noop_handler::NoOpHandler;
+
+#[cfg(feature = "full")]
+use rustc_version_runtime::version;
+
 #[cfg(feature = "full")]
 use voidstar_handler::VoidstarHandler;
 #[cfg(feature = "full")]
@@ -108,7 +111,7 @@ pub fn dispatch_output<T: Serialize + ?Sized>(json_data: &T) {
     let _ = LIB_HANDLER.output(s.as_str());
 }
 
-#[allow(dead_code)]
+#[cfg(feature = "full")]
 fn sdk_info() -> AntithesisSDKInfo {
     let language_data = AntithesisLanguageInfo {
         name: "Rust",

--- a/lib/src/internal/mod.rs
+++ b/lib/src/internal/mod.rs
@@ -39,9 +39,11 @@ struct AntithesisSDKInfo {
 }
 
 // Hardly ever changes, refers to the underlying JSON representation
+#[allow(dead_code)]
 const PROTOCOL_VERSION: &str = "1.0.0";
 
 // Tracks SDK releases
+#[allow(dead_code)]
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const LOCAL_OUTPUT: &str = "ANTITHESIS_SDK_LOCAL_OUTPUT";
@@ -58,6 +60,7 @@ fn get_handler() -> Box<dyn LibHandler + Sync + Send> {
 }
 
 #[cfg(not(feature = "full"))]
+#[allow(dead_code)]
 fn get_handler() -> Box<dyn LibHandler + Sync + Send> {
     Box::new(NoOpHandler::new())
 }
@@ -105,6 +108,7 @@ pub fn dispatch_output<T: Serialize + ?Sized>(json_data: &T) {
     let _ = LIB_HANDLER.output(s.as_str());
 }
 
+#[allow(dead_code)]
 fn sdk_info() -> AntithesisSDKInfo {
     let language_data = AntithesisLanguageInfo {
         name: "Rust",

--- a/lib/src/internal/noop_handler.rs
+++ b/lib/src/internal/noop_handler.rs
@@ -4,6 +4,7 @@ use std::io::Error;
 pub struct NoOpHandler {}
 
 impl NoOpHandler {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         NoOpHandler {}
     }

--- a/lib/src/internal/voidstar_handler.rs
+++ b/lib/src/internal/voidstar_handler.rs
@@ -6,6 +6,7 @@ use crate::internal::LibHandler;
 
 const LIB_NAME: &str = "/usr/lib/libvoidstar.so";
 
+
 pub struct VoidstarHandler {
     // Not used directly but exists to ensure the library is loaded
     // and all the following function pointers points to valid memory.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,6 +10,7 @@
 /// Each macro/function also takes a parameter called ``details``, which is a key-value map of optional additional information provided by the user to add context for assertion failures.
 /// The information that is logged will appear in the ``logs`` section of a [triage report](https://antithesis.com/docs/reports/triage.html).
 /// Normally the values in ``details`` are evaluated at runtime.
+#[cfg(feature = "full")]
 pub mod assert;
 
 // External crates used in assertion macros

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,8 +15,10 @@ pub mod assert;
 
 // External crates used in assertion macros
 #[doc(hidden)]
+#[cfg(feature = "full")]
 pub use linkme;
 #[doc(hidden)]
+#[cfg(feature = "full")]
 pub use once_cell;
 
 /// The lifecycle module contains functions which inform the Antithesis
@@ -68,8 +70,10 @@ pub mod prelude;
 /// ```
 #[allow(clippy::needless_doctest_main)]
 pub fn antithesis_init() {
-    Lazy::force(&internal::LIB_HANDLER);
-    Lazy::force(&assert::INIT_CATALOG);
+    if cfg!(feature = "full") {
+        Lazy::force(&internal::LIB_HANDLER);
+        Lazy::force(&assert::INIT_CATALOG);
+    }
 }
 
 use once_cell::sync::Lazy;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,7 +10,6 @@
 /// Each macro/function also takes a parameter called ``details``, which is a key-value map of optional additional information provided by the user to add context for assertion failures.
 /// The information that is logged will appear in the ``logs`` section of a [triage report](https://antithesis.com/docs/reports/triage.html).
 /// Normally the values in ``details`` are evaluated at runtime.
-#[cfg(feature = "full")]
 pub mod assert;
 
 // External crates used in assertion macros
@@ -70,12 +69,19 @@ pub mod prelude;
 /// ```
 #[allow(clippy::needless_doctest_main)]
 pub fn antithesis_init() {
-    if cfg!(feature = "full") {
-        Lazy::force(&internal::LIB_HANDLER);
-        Lazy::force(&assert::INIT_CATALOG);
-    }
+    init();
 }
 
+#[cfg(feature = "full")]
+fn init() {
+    Lazy::force(&internal::LIB_HANDLER);
+    Lazy::force(&assert::INIT_CATALOG);
+}
+
+#[cfg(not(feature = "full"))]
+fn init() {}
+
+#[cfg(feature = "full")]
 use once_cell::sync::Lazy;
 
 /// A constant provided by the SDK to report the location of logged output when run locally.

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-antithesis_sdk = { path = "../lib" }
+antithesis_sdk = { path = "../lib", default-features = false }
 serde_json = "1.0.25"
+
+
+[features]
+default = ["antithesis_sdk/full"]


### PR DESCRIPTION
Before this change we had the flag `no-antithesis-sdk` which would use the no-op handler only. This worked but was a bit of a rust anti pattern. 

We were not able to limit the number of dependencies used if the flag was on so you would still have linkme, once_cell, etc even though they weren't actually used.

So this changes makes it so we have a `full` feature flag that pulls in all the deps needed to use the sdk "for real". This feature is a part of the default feature set so it should work as before.

If you turn off default features for the sdk, it will be fully no-op and the only deps fulled in are serde related and rand.