### PR TITLE
Improve assertion macros

### DIFF
--- a/lib/src/assert/guidance.rs
+++ b/lib/src/assert/guidance.rs
@@ -165,6 +165,8 @@ macro_rules! impl_diff_signed {
 
             fn diff(&self, other: Self) -> Self::Output {
                 if *self < other {
+                    // For correctness, see
+                    // https://github.com/rust-lang/rust/blob/11e760b7f4e4aaa11bf51a64d4bb7f1171f6e466/library/core/src/num/int_macros.rs#L3443-L3456
                     -((other as $unsigned_t).wrapping_sub(*self as $unsigned_t) as f64)
                 } else {
                     (*self as $unsigned_t).wrapping_sub(other as $unsigned_t) as f64

--- a/lib/src/assert/mod.rs
+++ b/lib/src/assert/mod.rs
@@ -44,7 +44,6 @@ pub(crate) static ASSERT_TRACKER: Lazy<Mutex<HashMap<String, TrackingInfo>>> =
 
 #[cfg(feature = "full")]
 pub(crate) static INIT_CATALOG: Lazy<()> = Lazy::new(|| {
-    let no_details: Value = json!({});
     for info in ANTITHESIS_CATALOG.iter() {
         let f_name: &str = info.function.as_ref();
         assert_impl(
@@ -60,7 +59,7 @@ pub(crate) static INIT_CATALOG: Lazy<()> = Lazy::new(|| {
             false, /* hit */
             info.must_hit,
             info.id.to_owned(),
-            &no_details,
+            &json!(null),
         );
     }
     for info in ANTITHESIS_GUIDANCE_CATALOG.iter() {

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -80,9 +80,9 @@ fn assert_demo() {
     let details = json!({"impossible!": {"name": "trouble", "weights": [100,200,300]}});
     assert_unreachable!("Impossible to get here", &details);
 
-    assert_always_greater_than!(3, 100, "not right", &json!({}));
+    assert_always_greater_than!(3, 100, "not right");
 
-    assert_sometimes_all!({a: true, b: false}, "not all right", &json!({}));
+    assert_sometimes_all!({a: true, b: false}, "not all right");
 }
 
 pub fn main() {


### PR DESCRIPTION
Some ergonomics improvements for assertion macros.
- Provide custom compile errors when the macros are invoked with malformed syntax.
- Allow the details JSON argument to be optional in all macros.
- Allow trailing commas in the condition object for `sometimes_all` and `always_some`, and correctly handles the empty object case.
- Set `"details"` to `null` when reporting the assertion catalog.

Depends on #14 