### PR TITLE
feat: implement `rand::RngCore` for `AntithesisRng`

### DIFF
--- a/lib/src/random.rs
+++ b/lib/src/random.rs
@@ -55,11 +55,12 @@ pub fn random_choice<T>(slice: &[T]) -> Option<&T> {
 ///
 /// ```
 /// use antithesis_sdk::random::AntithesisRng;
-/// use rand::RngCore;
+/// use rand::{Rng, RngCore};
 ///
 /// let mut rng = AntithesisRng;
-/// let random_u32 = rng.next_u32();
-/// let random_u64 = rng.next_u64();
+/// let random_u32: u32 = rng.gen();
+/// let random_u64: u64 = rng.gen();
+/// let random_char: char = rng.gen();
 ///
 /// let mut bytes = [0u8; 16];
 /// rng.fill_bytes(&mut bytes);


### PR DESCRIPTION
Adds `AntithesisRng` struct implementing the `rand` crate's `RngCore` trait, allowing integration with the broader Rust random number generation ecosystem. The implementation uses the existing `get_random()` function and adds methods like `next_u32()`, `next_u64()`, and `fill_bytes()`. Includes comprehensive tests for the new functionality.

Key changes:
- Add `use rand::{Error, RngCore}`
- Create `AntithesisRng` struct with `RngCore` implementation
- Add tests using `rand::Rng` and `SliceRandom` traits