### PR TITLE
Alternative MSRV testing setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,20 @@ jobs:
     strategy:
       matrix:
         min-version: [true, false]
+        msrv:
+          - rust-version: 1.62.1
+            features: full
+          - rust-version: 1.62.1
+            features: ""
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: cachix/install-nix-action@v26
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - if: ${{ matrix.min-version }}
       run: nix develop . -c cargo update -Z minimal-versions
+    - run: nix develop .#msrv -c cargo msrv verify --rust-version ${{ matrix.msrv.rust-version }} --no-default-features --features "${{ matrix.msrv.features }}"
+      env:
+        CARGO_NET_GIT_FETCH_WITH_CLI: true # workaround slow index fetch: https://github.com/rust-lang/cargo/issues/11014
     - run: nix flake check --keep-going --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1714536327,
-        "narHash": "sha256-zu4+LcygJwdyFHunTMeDFltBZ9+hoWvR/1A7IEy7ChA=",
+        "lastModified": 1776396856,
+        "narHash": "sha256-aRJpIJUlZLaf06ekPvqjuU46zvO9K90IxJGpbqodkPs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3124551aebd8db15d4560716d4f903bd44c64e4a",
+        "rev": "28462d6d55c33206ffa5a56c7907ca3125ed788f",
         "type": "github"
       },
       "original": {
@@ -22,34 +17,16 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
       },
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
       }
     },
     "flakelight": {
@@ -57,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1714393927,
-        "narHash": "sha256-iypUnyPbTkRSTF2g17I36sI3X7eGThfQ8QnQ7WQxnjw=",
+        "lastModified": 1776088252,
+        "narHash": "sha256-VdOuruyWaPxxVYduxHUjHBcma196A7PNIqdMdqacE/4=",
         "owner": "nix-community",
         "repo": "flakelight",
-        "rev": "7a838aff6f7eba0c0d1a58250d8df8e83b25bb8d",
+        "rev": "56ebb2e6e0ac96742a36d71ff59ee24fff47ed19",
         "type": "github"
       },
       "original": {
@@ -72,26 +49,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714253743,
-        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714562304,
-        "narHash": "sha256-Mr3U37Rh6tH0FbaDFu0aZDwk9mPAe7ASaqDOGgLqqLU=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd44e224fd68ce7d269b4f44d24c2220fd821e7",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
@@ -103,11 +81,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -128,35 +106,19 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1714616033,
-        "narHash": "sha256-JcWAjIDl3h0bE/pII0emeHwokTeBl+SWrzwrjoRu7a0=",
+        "lastModified": 1776395632,
+        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3e416d5067ba31ff8ac31eeb763e4388bdf45089",
+        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     inherit inputs;
     withOverlays = [
       inputs.rust-overlay.overlays.default
-      (final: { lib, rust-bin, ... }:
+      (final: { rust-bin, ... }:
         let
           # version:
           # "latest" => latest stable
@@ -50,7 +50,6 @@
           antithesis-sdk-rust = {
             workspace = workspace "nightly";
             workspaceEmptyFeature = workspaceEmptyFeature "nightly";
-            workspaceMSRV = workspace (lib.importTOML ./lib/Cargo.toml).package.rust-version;
             clippy = clippy "nightly";
             test = test "nightly";
             doc = doc "nightly";
@@ -71,12 +70,16 @@
 
     devShells.default = pkgs: {
       inputsFrom = with pkgs; [ antithesis-sdk-rust.workspace ];
-      packages = with pkgs; [ rust-analyzer cargo-msrv ];
+      packages = with pkgs; [ rust-analyzer ];
+    };
+
+    devShells.msrv = pkgs: {
+      packages = with pkgs; [ cargo-msrv rustup ];
     };
 
     # TODO: Perform semver check.
     checks = { antithesis-sdk-rust, ... }: {
-      inherit (antithesis-sdk-rust) workspaceMSRV workspaceEmptyFeature clippy test;
+      inherit (antithesis-sdk-rust) workspaceEmptyFeature clippy test;
     };
 
     # TODO: Decide whether we want auto formatting.

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
     flakelight.url = "github:nix-community/flakelight";
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
@@ -16,13 +13,13 @@
     inherit inputs;
     withOverlays = [
       inputs.rust-overlay.overlays.default
-      (final: { inputs', lib, rust-bin, ... }:
+      (final: { lib, rust-bin, ... }:
         let
           # version:
           # "latest" => latest stable
           # "nightly" => latest nightly
           # "1.61.0" => specific stable version
-          craneLib = version: inputs'.crane.lib.overrideToolchain (if version == "nightly" then rust-bin.nightly.latest.default else rust-bin.stable.${version}.default);
+          craneLib = version: (inputs.crane.mkLib final).overrideToolchain (if version == "nightly" then rust-bin.nightly.latest.default else rust-bin.stable.${version}.default);
           commonArgs = {
             src = ./.;
             pname = "antithesis-sdk-rust-workspace";
@@ -63,8 +60,8 @@
 
     packages = rec {
       default = workspace;
-      workspace = { antithesis-sdk-rust }: antithesis-sdk-rust.workspace;
-      doc = { antithesis-sdk-rust }: antithesis-sdk-rust.doc;
+      workspace = pkgs: pkgs.antithesis-sdk-rust.workspace;
+      doc = pkgs: pkgs.antithesis-sdk-rust.doc;
     };
 
     apps = rec {


### PR DESCRIPTION
- Update our nix flake to use the latest nixpkgs and crane.
- Change the MSRV testing setup to directly use `cargo msrv verify` (from `cargo-msrv`) in the CI. The previous crane-based approach has some difficulties in dealing with edition incompatibilities due to how it vendors and do source replacement in cargo, and that leads to false positives.